### PR TITLE
fix locating civitai folder in custom named ComfyUI directories

### DIFF
--- a/API_civitai.py
+++ b/API_civitai.py
@@ -25,8 +25,8 @@ import subprocess
 
 def get_civitai_base_paths():
     """Returns common paths for CivitAI integration"""
-    custom_nodes_dir = Path(__file__).parent.parent.parent.parent
-    civitai_base_path = custom_nodes_dir / "ComfyUI" / "custom_nodes" / "Bjornulf_custom_nodes" / "civitai"
+    custom_nodes_dir = Path(__file__).parent.parent.parent
+    civitai_base_path = custom_nodes_dir /  "custom_nodes" / "Bjornulf_custom_nodes" / "civitai"
     return custom_nodes_dir, civitai_base_path, civitai_base_path  # Last one is parsed_models_path
 
 def setup_checkpoint_directory(model_type):


### PR DESCRIPTION


Related?: https://github.com/justUmen/Bjornulf_custom_nodes/issues/19


`/run/media/user/ssd/interfaces/ComfyUI` is not my install path. 
Using a custom named ComfyUI Directory e.g. `/run/media/user/ssd/interfaces/SomethingElse` causes errors.

Fix: by not traversing as many parents.

---
Error: 
```
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/sdxl_1.0
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/sd_1.5
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/pony
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/flux.1_d
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/flux.1_s
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/lora_sdxl_1.0
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/lora_sd_1.5
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/lora_pony
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/lora_flux.1_d
❌ Source path doesn't exist (checked both cases): /run/media/user/ssd/interfaces/ComfyUI/custom_nodes/Bjornulf_custom_nodes/civitai/lora_hunyuan_video
```


